### PR TITLE
Add basic cafe schedule demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# 523
+# Cafe Management Prototype
+
+This repository contains a simple prototype for a cafe management system.
+
+## Usage
+
+Open `cafe/index.html` in a web browser to view the schedule management demo. Data is stored locally in your browser using `localStorage`.
+
+The existing file `index.html` is unrelated to the cafe system and kept for reference.

--- a/cafe/index.html
+++ b/cafe/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>카페 관리 시스템 - 스케줄</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>카페 스케줄 관리</h1>
+<div id="schedule"></div>
+<button id="requestBtn">스케줄 변경 요청</button>
+<div id="requestForm" class="hidden">
+  <h2>변경 요청</h2>
+  <label>날짜: <input type="date" id="reqDate"></label>
+  <label>원래 근무: <input type="text" id="reqOriginal"></label>
+  <label>변경 요청: <input type="text" id="reqShift"></label>
+  <label>사유: <input type="text" id="reqReason"></label>
+  <button id="submitRequest">요청 제출</button>
+</div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/cafe/script.js
+++ b/cafe/script.js
@@ -1,0 +1,72 @@
+const defaultData = {
+  employees: [
+    { id: 1, name: '김대표', role: '대표' },
+    { id: 2, name: '이매니저', role: '매니저' },
+    { id: 3, name: '박직원', role: '직원' }
+  ],
+  planned_schedule: {
+    '2025-07-01': {
+      morning: { employee_id: 1, start: '09:00', end: '14:00' },
+      afternoon: { employee_id: 2, start: '14:00', end: '20:00' }
+    }
+  },
+  schedule_requests: []
+};
+
+function loadData() {
+  const data = JSON.parse(localStorage.getItem('cafeData') || 'null');
+  if (data) return data;
+  localStorage.setItem('cafeData', JSON.stringify(defaultData));
+  return JSON.parse(JSON.stringify(defaultData));
+}
+
+function saveData(data) {
+  localStorage.setItem('cafeData', JSON.stringify(data));
+}
+
+function renderSchedule() {
+  const data = loadData();
+  const scheduleDiv = document.getElementById('schedule');
+  const table = document.createElement('table');
+  const header = document.createElement('tr');
+  header.innerHTML = '<th>날짜</th><th>오전</th><th>오후</th>';
+  table.appendChild(header);
+  Object.keys(data.planned_schedule).forEach(date => {
+    const row = document.createElement('tr');
+    const morning = data.planned_schedule[date].morning;
+    const afternoon = data.planned_schedule[date].afternoon;
+    row.innerHTML = `<td>${date}</td><td>${nameById(morning.employee_id)} ${morning.start}-${morning.end}</td><td>${nameById(afternoon.employee_id)} ${afternoon.start}-${afternoon.end}</td>`;
+    table.appendChild(row);
+  });
+  scheduleDiv.innerHTML = '';
+  scheduleDiv.appendChild(table);
+}
+
+function nameById(id) {
+  const data = loadData();
+  const emp = data.employees.find(e => e.id === id);
+  return emp ? emp.name : '';
+}
+
+document.getElementById('requestBtn').addEventListener('click', () => {
+  document.getElementById('requestForm').classList.toggle('hidden');
+});
+
+document.getElementById('submitRequest').addEventListener('click', () => {
+  const date = document.getElementById('reqDate').value;
+  const original = document.getElementById('reqOriginal').value;
+  const shift = document.getElementById('reqShift').value;
+  const reason = document.getElementById('reqReason').value;
+  if (!date || !shift) {
+    alert('날짜와 변경 요청을 입력하세요.');
+    return;
+  }
+  const data = loadData();
+  const id = Date.now();
+  data.schedule_requests.push({ id, employee_id: 3, requested_date: date, original_shift: original, requested_shift: shift, reason, status: 'pending', request_date: new Date().toISOString() });
+  saveData(data);
+  alert('요청이 저장되었습니다.');
+  document.getElementById('requestForm').classList.add('hidden');
+});
+
+renderSchedule();

--- a/cafe/style.css
+++ b/cafe/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; padding: 20px; }
+.hidden { display: none; }
+table { border-collapse: collapse; width: 100%; margin-bottom: 20px; }
+th, td { border: 1px solid #ccc; padding: 8px; text-align: center; }


### PR DESCRIPTION
## Summary
- add a simple cafe schedule prototype in a new `cafe` folder
- include basic style and script for viewing planned schedule and submitting change requests
- update README with instructions

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68635cbc3fc8832c802b518f12676963